### PR TITLE
revise

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## 0.3.0 (2019-04-20)
+
+* breaking: remove S.pp and K.pp, they weren't necessary and imposed a Fmt dependency
+* breaking: remove S.findb, S.getb, S.addb, S.addb_unless_bound -- use S.find, S.get, S.add, S.add_unless_bound instead
+* S.equal, S.map, S.merge, and S.union use semi-explicit polymorphism with a record type
+* breaking: S.equal signature is now : { f : 'a key -> 'a -> 'a -> bool } -> t -> t -> bool
+* new function S.map : { f : 'a key -> 'a -> 'a } -> t -> t
+* breaking: S.merge signature is now : { f : 'a key -> 'a option -> 'a option -> 'a option } -> t -> t -> t
+* breaking: S.union signature is now : { f : 'a key -> 'a -> 'a -> 'a option } -> t -> t -> t
+* added some tests
+
 ## 0.2.1 (2019-02-16)
 
 * move build system to dune

--- a/README.md
+++ b/README.md
@@ -10,23 +10,18 @@ This removes the need for additional packing.  It uses OCaml's stdlib
 structure.
 
 ```OCaml
-type _ k =
-  | A : int k
-  | B : string k
+type _ key =
+  | I : int key
+  | S : string key
 
 module K = struct
-  type 'a t = 'a k
+  type 'a t = 'a key
 
   let compare : type a b. a t -> b t -> (a, b) Gmap.Order.t = fun t t' ->
     let open Gmap.Order in
     match t, t' with
-    | A, A -> Eq | A, _ -> Lt | _, A -> Gt
-    | B, B -> Eq
-
-  let pp : type a. Format.formatter -> a t -> a -> unit = fun ppf t v ->
-    match t, v with
-    | A, x -> Fmt.pf ppf "A %d" x
-    | B, s -> Fmt.pf ppf "B %s" s
+    | I, I -> Eq | I, _ -> Lt | _, I -> Gt
+    | S, S -> Eq
 end
 
 module M = Gmap.Make(K)
@@ -35,7 +30,7 @@ module M = Gmap.Make(K)
 let () =
   let m = M.empty in
   ...
-  match M.find A m with
+  match M.find I m with
   | Some x -> Printf.printf "got %d\n" x
   | None -> Printf.printf "found nothing\n"
 ```

--- a/dune
+++ b/dune
@@ -2,3 +2,8 @@
   (name gmap)
   (public_name gmap)
   (modules gmap))
+
+(test
+  (name tests)
+  (modules tests)
+  (libraries alcotest fmt gmap))

--- a/dune
+++ b/dune
@@ -1,5 +1,4 @@
 (library
   (name gmap)
   (public_name gmap)
-  (modules gmap)
-  (libraries fmt))
+  (modules gmap))

--- a/gmap.ml
+++ b/gmap.ml
@@ -30,10 +30,7 @@ module type S = sig
   val remove : 'a key -> t -> t
   val update : 'a key -> ('a option -> 'a option) -> t -> t
 
-  type k = K : 'a key -> k
   type b = B : 'a key * 'a -> b
-
-  val comparek : k -> k -> int
 
   val min_binding : t -> b option
   val max_binding : t -> b option
@@ -62,12 +59,10 @@ module Make (Key : KEY) : S with type 'a key = 'a Key.t = struct
   type k = K : 'a key -> k
   type b = B : 'a key * 'a -> b
 
-  let comparek (K a) (K b) = match Key.compare a b with
-    | Order.Lt -> -1 | Order.Eq -> 0 | Order.Gt -> 1
-
   module M = Map.Make(struct
       type t = k
-      let compare = comparek
+      let compare (K a) (K b) = match Key.compare a b with
+        | Order.Lt -> -1 | Order.Eq -> 0 | Order.Gt -> 1
     end)
 
   type t = b M.t

--- a/gmap.ml
+++ b/gmap.ml
@@ -12,7 +12,6 @@ end
 module type KEY = sig
   type _ t
   val compare : 'a t -> 'b t -> ('a, 'b) Order.t
-  val pp : Format.formatter -> 'a t -> 'a -> unit
 end
 
 module type S = sig
@@ -60,7 +59,6 @@ module type S = sig
   val filter : (b -> bool) -> t -> t
   val merge : (b option -> b option -> b option) -> t -> t -> t
   val union : (b -> b -> b option) -> t -> t -> t
-  val pp : Format.formatter -> t -> unit
 end
 
 module Make (Key : KEY) : S with type 'a key = 'a Key.t = struct
@@ -142,12 +140,6 @@ module Make (Key : KEY) : S with type 'a key = 'a Key.t = struct
   let merge f m m' = M.merge (fun _ b b' -> f b b') m m'
 
   let union f m m' = M.union (fun _ b b' -> f b b') m m'
-
-  let pp ppf m =
-    let pp ppf = function
-      | B (k, v) -> Key.pp ppf k v
-    in
-    Fmt.(list ~sep:(unit "@.") pp) ppf (bindings m)
 
   let equal cmp m m' = M.equal cmp m m'
 end

--- a/gmap.mli
+++ b/gmap.mli
@@ -28,23 +28,18 @@
     A simple example:
 
 {[
-type _ k =
-  | A : int k
-  | B : string k
+type _ key =
+  | A : int key
+  | B : string key
 
 module K = struct
-  type 'a t = 'a k
+  type 'a t = 'a key
 
   let compare : type a b. a t -> b t -> (a, b) Gmap.Order.t = fun t t' ->
     let open Gmap.Order in
     match t, t' with
     | A, A -> Eq | A, _ -> Lt | _, A -> Gt
     | B, B -> Eq
-
-  let pp : type a. Format.formatter -> a t -> a -> unit = fun ppf t v ->
-    match t, v with
-    | A, x -> Fmt.pf ppf "A %d" x
-    | B, s -> Fmt.pf ppf "B %s" s
 end
 
 module GM = Gmap.Make(K)

--- a/gmap.mli
+++ b/gmap.mli
@@ -29,8 +29,8 @@
 
 {[
 type _ key =
-  | A : int key
-  | B : string key
+  | I : int key
+  | S : string key
 
 module K = struct
   type 'a t = 'a key
@@ -38,8 +38,8 @@ module K = struct
   let compare : type a b. a t -> b t -> (a, b) Gmap.Order.t = fun t t' ->
     let open Gmap.Order in
     match t, t' with
-    | A, A -> Eq | A, _ -> Lt | _, A -> Gt
-    | B, B -> Eq
+    | I, I -> Eq | I, _ -> Lt | _, I -> Gt
+    | S, S -> Eq
 end
 
 module GM = Gmap.Make(K)
@@ -48,7 +48,7 @@ module GM = Gmap.Make(K)
     Using [GM] is done as follows:
 
 {[
-match GM.find A m with
+match GM.find I m with
 | Some x -> x * x
 | None -> 0
 ]}
@@ -228,4 +228,6 @@ module type S = sig
 end
 
 (** Functor for heterogenous maps whose keys are provided by [Key]. *)
-module Make : functor (Key : KEY) -> S with type 'a key = 'a Key.t
+module Make (Key : KEY) : sig
+  include S with type 'a key = 'a Key.t
+end

--- a/gmap.mli
+++ b/gmap.mli
@@ -138,18 +138,10 @@ module type S = sig
       [f (find k m)], the binding of [k] is added, removed, or updated. *)
 
 
-  (** {2 Keys and Bindings} *)
-
-  type k = K : 'a key -> k
-  (** The monomorphic type of a key. *)
+  (** {2 Bindings} *)
 
   type b = B : 'a key * 'a -> b
   (** The type for a binding: a pair containing a key and its value. *)
-
-  (** {2 Key operations} *)
-
-  val comparek : k -> k -> int
-  (** [compare k k'] compares [k] with [k'], using the ordering. *)
 
   (** {2 Selection of bindings} *)
 

--- a/gmap.mli
+++ b/gmap.mli
@@ -145,12 +145,37 @@ module type S = sig
       for the binding [v] of [k].  Depending the value of [v], which is
       [f (find k m)], the binding of [k] is added, removed, or updated. *)
 
-  (** {2 Bindings} *)
+
+  (** {2 Keys and Bindings} *)
+
+  type k = K : 'a key -> k
+  (** The monomorphic type of a key. *)
 
   type b = B : 'a key * 'a -> b
   (** The type for a binding: a pair containing a key and its value. *)
 
-  (** {2 Selection} *)
+  (** {2 Key operations} *)
+
+  val comparek : k -> k -> int
+  (** [compare k k'] compares [k] with [k'], using the ordering. *)
+
+  val memk : k -> t -> bool
+  (** [memk key m] returns [true] if the map [m] contains a binding for [key]. *)
+
+  val getk : k -> t -> b
+  (** [k key m] returns [Some v] if the binding of [key] in [m] is [v], or
+      [None] if [key] is not bound [m]. *)
+
+  val findk : k -> t -> b option
+  (** [findk key m] returns [Some v] if the binding of [key] in [m] is [v], or
+      [None] if [key] is not bound [m]. *)
+
+  val removek : k -> t -> t
+  (** [removek key m] returns a map containing the same bindings as [m], except
+      for [key] which is not bound in the returned map.  If [key] was not bound
+      in [m], [m] is returned unchanged. *)
+
+  (** {2 Selection of bindings} *)
 
   val min_binding : t -> b option
   (** [min_binding m] is the minimal binding in [m], [None] if [m] is empty. *)
@@ -165,7 +190,7 @@ module type S = sig
   (** [bindings m] returns the list of all bindings in the given map [m].  The
       list is sorted with respect to the ordering over the type of the keys. *)
 
-  (** {2 Lookup} *)
+  (** {2 Lookup of bindings} *)
 
   val findb : 'a key -> t -> b option
   (** [findb key m] returns [Some b] if the binding of [key] in [m] is [b], or
@@ -177,7 +202,7 @@ module type S = sig
       @raise Not_found if [m] does not contain a binding for [key]. *)
 
 
-  (** {2 Insertion} *)
+  (** {2 Insertion of bindings} *)
 
   val addb_unless_bound : b -> t -> t option
   (** [addb_unless_bound b m] returns [Some m'], a map containing the

--- a/gmap.mli
+++ b/gmap.mli
@@ -166,33 +166,16 @@ module type S = sig
   (** [bindings m] returns the list of all bindings in the given map [m].  The
       list is sorted with respect to the ordering over the type of the keys. *)
 
-  (** {2 Lookup of bindings} *)
+  (** {2 Higher-order functions} *)
 
-  val findb : 'a key -> t -> b option
-  (** [findb key m] returns [Some b] if the binding of [key] in [m] is [b], or
-      [None] if [key] is not bound in [t]. *)
+  type eq = { f : 'a . 'a key -> 'a -> 'a -> bool }
+  (** The function type for the equal operation, using a record type for
+      "first-class" semi-explicit polymorphism. *)
 
-
-  (** {2 Insertion of bindings} *)
-
-  val addb_unless_bound : b -> t -> t option
-  (** [addb_unless_bound b m] returns [Some m'], a map containing the
-      same bindings as [m], plus the binding [b].  Or, [None] if
-      [key], the first part of [b], was already bound in [m]. *)
-
-  val addb : b -> t -> t
-  (** [addb b m] returns a map containing the same bindings as [m], plus the
-      binding [b].  If [key], the first part of [b] was already bound in [m],
-      the previous binding disappears. *)
-
-  (** {2 Equality} *)
-
-  val equal : (b -> b -> bool) -> t -> t -> bool
+  val equal : eq -> t -> t -> bool
   (** [equal p m m'] tests whether the maps [m] and [m'] are equal, that is
       contain equal keys and associate them with equal data.  [p] is the
       equality predicate used to compare the data associated with the keys. *)
-
-  (** {2 Higher-order functions} *)
 
   type mapper = { f : 'a. 'a key -> 'a -> 'a }
   (** The function type for the map operation, using a record type for

--- a/gmap.mli
+++ b/gmap.mli
@@ -78,9 +78,6 @@ module type KEY = sig
 
   val compare : 'a t -> 'b t -> ('a, 'b) Order.t
   (** [compare k k'] is the total order of keys. *)
-
-  val pp : Format.formatter -> 'a t -> 'a -> unit
-  (** [pp k] is the pretty-printer. *)
 end
 
 (** Output signature of the functor {!Make} *)
@@ -252,11 +249,6 @@ module type S = sig
   (** [union f m m'] computes a map whose keys is the union of the keys of [m]
       and [m'].  When the same binding is defined in both maps, the function [f]
       is used to combine them. *)
-
-  (** {2 Pretty printer} *)
-
-  val pp : Format.formatter -> t -> unit
-  (** [pp fmt m] is a pretty printer of the map [m]. *)
 end
 
 (** Functor for heterogenous maps whose keys are provided by [Key]. *)

--- a/gmap.opam
+++ b/gmap.opam
@@ -8,10 +8,13 @@ bug-reports: "https://github.com/hannesm/gmap/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build}
+  "alcotest" {with-test}
+  "fmt" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/hannesm/gmap.git"
 synopsis: "Heterogenous maps over a GADT"

--- a/gmap.opam
+++ b/gmap.opam
@@ -8,7 +8,6 @@ bug-reports: "https://github.com/hannesm/gmap/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build}
-  "fmt"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/tests.ml
+++ b/tests.ml
@@ -28,7 +28,7 @@ module M = Gmap.Make(K)
 let m_check =
   let module M = struct
     type t = M.t
-    let pp ppf m = M.iter (fun (B (k, v)) -> pp_m ppf k v) m
+    let pp ppf m = M.iter (fun (M.B (k, v)) -> pp_m ppf k v) m
     let equal a b = M.equal { f = eq_m } a b
   end in
   (module M: Alcotest.TESTABLE with type t = M.t)

--- a/tests.ml
+++ b/tests.ml
@@ -1,0 +1,160 @@
+
+type _ key =
+  | I : int key
+  | S : string key
+
+let pp_m : type a . Format.formatter -> a key -> a -> unit = fun ppf k v ->
+  match k, v with
+  | I, x -> Fmt.pf ppf "I %d" x
+  | S, s -> Fmt.pf ppf "S %s" s
+
+let eq_m : type a. a key -> a -> a -> bool = fun k v v' ->
+  match k, v, v' with
+  | I, x, y -> x = y
+  | S, s, t -> String.equal s t
+
+module K = struct
+  type 'a t = 'a key
+
+  let compare : type a b. a t -> b t -> (a, b) Gmap.Order.t = fun t t' ->
+    let open Gmap.Order in
+    match t, t' with
+    | I, I -> Eq | I, _ -> Lt | _, I -> Gt
+    | S, S -> Eq
+end
+
+module M = Gmap.Make(K)
+
+let m_check =
+  let module M = struct
+    type t = M.t
+    let pp ppf m = M.iter (fun (B (k, v)) -> pp_m ppf k v) m
+    let equal a b = M.equal { f = eq_m } a b
+  end in
+  (module M: Alcotest.TESTABLE with type t = M.t)
+
+let b_check =
+  let module M = struct
+    type t = M.b
+    let pp ppf (M.B (k, v)) = pp_m ppf k v
+    let equal (M.B (k, v)) (M.B (k', v')) = match K.compare k k' with
+      | Gmap.Order.Eq -> eq_m k v v'
+      | _ -> false
+  end in
+  (module M: Alcotest.TESTABLE with type t = M.t)
+
+let empty () =
+  Alcotest.(check bool "empty map is empty" true (M.is_empty M.empty));
+  Alcotest.(check bool "mem on empty map doesn't have A" false (M.mem I M.empty));
+  Alcotest.(check (option int) "find on empty map doesn't have A" None
+              (M.find I M.empty));
+  Alcotest.(check (option string) "find on empty map doesn't have B" None
+              (M.find S M.empty));
+  Alcotest.(check (option b_check) "min binding is none" None
+              (M.min_binding M.empty));
+  Alcotest.(check (option b_check) "max binding is none" None
+              (M.max_binding M.empty));
+  Alcotest.(check (option b_check) "any binding is none" None
+              (M.any_binding M.empty));
+  Alcotest.(check (list b_check) "bindings is empty" []
+              (M.bindings M.empty))
+
+let basic () =
+  let m = M.singleton I 5 in
+  Alcotest.(check bool "non-empty map is not empty" false (M.is_empty m));
+  Alcotest.(check int "non-empty map has cardinal 1" 1 (M.cardinal m));
+  Alcotest.(check bool "non-empty map has member I" true (M.mem I m));
+  Alcotest.(check (option int) "non-empty map finds I" (Some 5) (M.find I m));
+  Alcotest.check m_check "singleton and add are equivalent" m (M.add I 5 M.empty);
+  Alcotest.(check bool "removing I from map makes it empty" true
+              (M.is_empty (M.remove I m)));
+  Alcotest.(check bool "removing S from map makes it not empty" false
+              (M.is_empty (M.remove S m)));
+  Alcotest.check m_check "add overwrites" (M.singleton I 10) (M.add I 10 m);
+  Alcotest.(check (option m_check) "add_unless_bound does not overwrite" None
+              (M.add_unless_bound I 10 m));
+  Alcotest.check m_check "update updates" (M.singleton I 20)
+    (M.update I (fun _ -> Some 20) m);
+  Alcotest.(check (option b_check) "min_binding is I 5" (Some (M.B (I, 5)))
+              (M.min_binding m));
+  Alcotest.(check (option b_check) "max_binding is I 5" (Some (M.B (I, 5)))
+              (M.max_binding m));
+  Alcotest.(check (option b_check) "any_binding is I 5" (Some (M.B (I, 5)))
+              (M.any_binding m));
+  Alcotest.(check (list b_check) "bindings is [ I 5 ]" [ M.B (I, 5) ]
+              (M.bindings m))
+
+let bad_eq_false : type a. a key -> a -> a -> bool = fun _ _ _ -> false
+let bad_eq_true : type a. a key -> a -> a -> bool = fun _ _ _ -> true
+
+let eq () =
+  let m = M.singleton I 5 in
+  Alcotest.(check bool "m equal is ok" true (M.equal { f = eq_m } m m));
+  Alcotest.(check bool "m equal is ok with singleton" true
+              (M.equal { f = eq_m } m (M.singleton I 5)));
+  Alcotest.(check bool "m equal is false" false
+              (M.equal { f = eq_m } m M.empty));
+  Alcotest.(check bool "m equal is false" false
+              (M.equal { f = eq_m } m (M.singleton S "foo")));
+  Alcotest.(check bool "m equal is false" false
+              (M.equal { f = eq_m } m (M.singleton I 10)));
+  Alcotest.(check bool "m equal is false" false
+              (M.equal { f = eq_m } m (M.add S "foo" (M.singleton I 10))));
+  Alcotest.(check bool "m bad equal is always false" false
+              (M.equal { f = bad_eq_false } m m));
+  Alcotest.(check bool "m bad equal is always true" true
+              (M.equal { f = bad_eq_true } m m))
+
+let preds () =
+  let m = M.singleton I 5 in
+  let m' = M.add S "foobar" m in
+  let m'' = M.singleton I 10 in
+  let p (M.B (k, v)) = match k with I -> v = 5 | _ -> false in
+  Alcotest.(check bool "for_all works" true (M.for_all p m));
+  Alcotest.(check bool "for_all works m'" false (M.for_all p m'));
+  Alcotest.(check bool "for_all works m''" false (M.for_all p m''));
+  Alcotest.(check bool "exists works" true (M.exists p m));
+  Alcotest.(check bool "exists works m'" true (M.exists p m'));
+  Alcotest.(check bool "exists works m''" false (M.exists p m''));
+  Alcotest.check m_check "filter works" m (M.filter p m);
+  Alcotest.check m_check "filter works m'" m (M.filter p m');
+  Alcotest.check m_check "filter works m''" M.empty (M.filter p m'')
+
+let map () =
+  let m = M.singleton I 5 in
+  let map : type a . a key -> a -> a = fun k _v ->
+    match k with
+    | I -> 100
+    | S -> "Foo"
+  in
+  Alcotest.check m_check "mapped m is equal as expected"
+    (M.singleton I 100) (M.map { f = map } m);
+  Alcotest.check m_check "mapped m is equal as expected"
+    (M.add S "Foo" (M.singleton I 100))
+    (M.map { f = map } (M.add S "barf" m))
+
+let l_wins : type a . a key -> a -> a -> a option = fun _ v _ -> Some v
+let r_wins : type a . a key -> a -> a -> a option = fun _ _ v' -> Some v'
+let no_wins : type a . a key -> a -> a -> a option = fun _ _ _ -> None
+
+let union () =
+  let m = M.add I 100 (M.singleton S "foo") in
+  Alcotest.check m_check "union map left wins is good" m
+    (M.union { f = l_wins } m (M.singleton S "bar"));
+  Alcotest.check m_check "union map right wins is good"
+    (M.add I 100 (M.singleton S "bar"))
+    (M.union { f = r_wins } m (M.singleton S "bar"));
+  Alcotest.check m_check "union map right wins is good"
+    (M.singleton I 100)
+    (M.union { f = no_wins } m (M.singleton S "bar"))
+
+let tests = [
+  "empty gmap", `Quick, empty ;
+  "basic gmap", `Quick, basic ;
+  "equality", `Quick, eq ;
+  "predicates", `Quick, preds ;
+  "map", `Quick, map ;
+  "union", `Quick, union ;
+]
+
+let () = Alcotest.run "gmap tests" [ "gmap suite", tests ]


### PR DESCRIPTION
- no longer `pp`, drop dependency on fmt (breaks API)
- expose monomorphic `type k = K : 'a key -> k` (breaks API as well 
- provide `comparek/memk/getk/findk/removek` which use above `k`
- cleanup example