### PR TITLE
compare_length_with

### DIFF
--- a/gmap.ml
+++ b/gmap.ml
@@ -22,6 +22,7 @@ module type S = sig
   val singleton : 'a key -> 'a -> t
   val is_empty : t -> bool
   val cardinal : t -> int
+  val compare_length_with : t -> int -> int
   val mem : 'a key -> t -> bool
   val find : 'a key -> t -> 'a option
   val get : 'a key -> t -> 'a
@@ -111,6 +112,11 @@ module Make (Key : KEY) : S with type 'a key = 'a Key.t = struct
   let bindings m = snd (List.split (M.bindings m))
 
   let cardinal m = M.cardinal m
+
+  let compare_length_with t num =
+    let seen = ref 0 in
+    let _ = M.find_first_opt (fun _ -> incr seen; !seen > num) t in
+    !seen - num
 
   let for_all p m = M.for_all (fun _ b -> p b) m
   let exists p m = M.exists (fun _ b -> p b) m

--- a/gmap.mli
+++ b/gmap.mli
@@ -103,6 +103,20 @@ module type S = sig
   val cardinal : t -> int
   (** [cardinal m] returns the number of bindings of the map [m]. *)
 
+  val compare_length_with : t -> int -> int
+  (** [compare_length_with t num] is equivalent to
+      [compare (cardinal t) num], but returns early when [num < cardinal t]
+      to avoid iterating over the entire map.
+      The upper algorithmic performance bound is thus
+      [O( min(num+1, cardinal) )] instead of [O(cardinal)].
+      That is useful when you frequently need to compare the
+      cardinality of a potentially large map with a smaller number.
+      It is [0] if the two numbers are equal;
+      negative if [cardinal t < num];
+      positive if [cardinal t > num].
+      See {!List.compare_length_with}.
+  *)
+
   (** {2 Lookup operations} *)
 
   val mem : 'a key -> t -> bool

--- a/tests.ml
+++ b/tests.ml
@@ -148,6 +148,41 @@ let union () =
     (M.singleton I 100)
     (M.union { f = no_wins } m (M.singleton S "bar"))
 
+let compare_length_with () =
+  let m0 = M.empty in
+  let m1 = M.add I 0 m0 in
+  let m2 = M.add S "foo" m1 in
+  Alcotest.check Alcotest.int "(empty) 0 = 0"
+    0 (M.compare_length_with m0 0);
+  Alcotest.check Alcotest.bool "(empty) 1 < 0"
+    true (M.compare_length_with m0 1 < 0);
+  Alcotest.check Alcotest.bool "(empty) 1 < 0"
+    true (M.compare_length_with m0 1 < 0);
+  Alcotest.check Alcotest.int "(singleton) 1 = 0"
+    0 (M.compare_length_with m1 1);
+  Alcotest.check Alcotest.bool "(singleton) 0 > 0"
+    true (M.compare_length_with m1 0 > 0);
+  Alcotest.check Alcotest.bool "(singleton) 2 < 0"
+    true (M.compare_length_with m1 2 < 0);
+  Alcotest.check Alcotest.bool "(m1) 500 < 0"
+    true (M.compare_length_with m1 500 < 0);
+  Alcotest.check Alcotest.bool "(m1) 0 > 0"
+    true (M.compare_length_with m1 0 > 0 );
+  Alcotest.check Alcotest.int "(m1) 1 = 0"
+    0 (M.compare_length_with m1 1);
+  Alcotest.check Alcotest.bool "(m1) 2 < 0"
+    true (M.compare_length_with m1 2 < 0);
+  Alcotest.check Alcotest.bool "(m2) 0 > 0"
+    true (M.compare_length_with m2 0 > 0);
+  Alcotest.check Alcotest.bool "(m2) 500 < 0"
+    true (M.compare_length_with m2 500 < 0);
+  Alcotest.check Alcotest.bool "(m2) 1 > 0"
+    true (M.compare_length_with m2 1 > 0 );
+  Alcotest.check Alcotest.int "(m2) 2 = 0"
+    0 (M.compare_length_with m2 2);
+  Alcotest.check Alcotest.bool "(m2) 3 < 0"
+    true (M.compare_length_with m2 3 < 0)
+
 let tests = [
   "empty gmap", `Quick, empty ;
   "basic gmap", `Quick, basic ;
@@ -155,6 +190,7 @@ let tests = [
   "predicates", `Quick, preds ;
   "map", `Quick, map ;
   "union", `Quick, union ;
+  "compare_length_with", `Quick, compare_length_with;
 ]
 
 let () = Alcotest.run "gmap tests" [ "gmap suite", tests ]


### PR DESCRIPTION
This PR provides a `compare_length_with` in the style of `List.compare_length_with` (hence the name).
It serves the same purpose as `List.compare_length_with`: It can be used to replace instances like
```ocaml
if 6 = M.cardinal t then
```
(which runs in `O(n)` time and may be very slow with a large `t`) with
```ocaml
if 0 = M.compare_length_with t 6 then
```
(which runs in `O( min(cardinal t, 6+1) )` time).

Two examples of where this can be useful, but I suspect this is a fairly common use-case in code:
- https://github.com/roburio/udns/blob/4493b1ca50c749d3dbeb013f0a2d2bf6fb9b2fbc/server/dns_server.ml#L130
- https://github.com/roburio/udns/blob/4493b1ca50c749d3dbeb013f0a2d2bf6fb9b2fbc/server/dns_trie.ml#L78
