### PR TITLE
fix signature of fold2

### DIFF
--- a/gmap.ml
+++ b/gmap.ml
@@ -48,8 +48,8 @@ module type S = sig
   val for_all : (b -> bool) -> t -> bool
   val exists : (b -> bool) -> t -> bool
   val filter : (b -> bool) -> t -> t
-  type fold2 = { f : 'a 'b. 'a key -> 'a option -> 'a option -> 'b -> 'b }
-  val fold2 : fold2 -> t -> t -> 'a -> 'a
+  type 'a fold2 = { f : 'b. 'b key -> 'b option -> 'b option -> 'a -> 'a }
+  val fold2 : 'a fold2 -> t -> t -> 'a -> 'a
   type merger = { f : 'a. 'a key -> 'a option -> 'a option -> 'a option }
   val merge : merger -> t -> t -> t
   type unionee = { f : 'a. 'a key -> 'a -> 'a -> 'a option }
@@ -145,7 +145,7 @@ module Make (Key : KEY) : S with type 'a key = 'a Key.t = struct
       )
       m m'
 
-  type fold2 = { f : 'a 'b. 'a key -> 'a option -> 'a option -> 'b -> 'b }
+  type 'a fold2 = { f : 'b. 'b key -> 'b option -> 'b option -> 'a -> 'a }
 
   let fold2 f m m' acc =
     let local = ref acc in

--- a/gmap.mli
+++ b/gmap.mli
@@ -201,11 +201,11 @@ module type S = sig
   (** [filter p m] returns the map with all the bindings in [m] that satisfy
       [p]. *)
 
-  type fold2 = { f : 'a 'b. 'a key -> 'a option -> 'a option -> 'b -> 'b }
+  type 'a fold2 = { f : 'b. 'b key -> 'b option -> 'b option -> 'a -> 'a }
   (** The function type for the fold2 operation, using a record type for
       "first-class" semi-explicit polymorphism. *)
 
-  val fold2 : fold2 -> t -> t -> 'a -> 'a
+  val fold2 : 'a fold2 -> t -> t -> 'a -> 'a
   (** [fold2 f m m' acc] iterates over [m] and [m'], and calls [f] for each
       binding in [m] or [m']. It uses [Map.merge] for the folding, but
       ignores the result. *)


### PR DESCRIPTION
otherwise getting into trouble when attempting to provide a `f` for `fold2`:
```OCaml
This field value has type
         'c.
           'c key ->
           'c option ->
           'c option ->
           (Conf_map.t, [> Rresult.R.msg ] as 'd) result ->
           (Conf_map.t, 'd) result
       which is less general than
         'a 'b. 'a key -> 'a option -> 'a option -> 'b -> 'b
```